### PR TITLE
Fix reset-free bootloader entry: reboot with magic-as-type (GPREGRET clobber)

### DIFF
--- a/tools/kbd-flash/BENCH.md
+++ b/tools/kbd-flash/BENCH.md
@@ -57,12 +57,19 @@ set the rate on first open — so PRIME to another rate first:
 
 A bare `stty 1200` is a no-op change and will NOT trigger — confirmed on macOS.
 
-VERIFY ON HARDWARE (the parts native_sim could not):
-- [ ] After the primed 9600->1200 touch, the half reboots and `NICENANO`
-      mass-storage mounts (exercises the real GPREGRET=0x57 -> UF2 handoff).
-      NOTE: the first hardware run reached the reboot but landed in normal fw —
-      the build had RETENTION_BOOT_MODE off so the magic was never written.
-      Fixed: nRF52 now writes 0x57 to GPREGRET[0] directly (run 27514396150+).
+VERIFIED ON HARDWARE (the parts native_sim could not):
+- [x] Primed 9600->1200 touch -> half reboots -> `NICENANO` mounts reset-free
+      (real GPREGRET=0x57 -> UF2 handoff). LEFT half: 5/5 trials, immediate and
+      settled. Right half: identical fw, expected to work, not yet tested.
+- [x] Two bugs found + fixed on hardware along the way:
+      1. Build had RETENTION_BOOT_MODE off -> module took #else -> bare reboot,
+         magic never written (run <=27514396150).
+      2. The nRF path then wrote GPREGRET=0x57 but fell through to
+         sys_reboot(SYS_REBOOT_WARM); with NRF_STORE_REBOOT_TYPE_GPREGRET=y,
+         sys_reboot writes its arg to GPREGRET[0], so WARM(0) CLOBBERED the
+         magic (entry worked ~1/11, that success was double-reset detection).
+      FIX (fix/gpregret-reboot): reboot via sys_reboot(0x57) — magic as the
+      reboot type — so the store writes the magic instead of clobbering it.
 - [x] Running serial vs bootloader serial: SETTLED — identical 16-hex, no byte
       reorder (e.g. 8905AEEAAFB95703). The orchestrator does not rely on this.
 

--- a/tools/kbd-flash/PROGRESS.md
+++ b/tools/kbd-flash/PROGRESS.md
@@ -92,6 +92,17 @@ ALL GREEN). 32 host tests + 1500-trial fuzz + native_sim+usbip fw test.
 - 39 tests green. SOFTWARE COMPLETE — switching loop to long idle intervals;
   only hardware-gated bench work remains (BENCH.md).
 
+## Hardware test #2/#3 — RESOLVED, validated 5/5 (left half)
+The "fix" from test #1 (direct GPREGRET write) did NOT actually work: detection +
+reboot were reliable on both halves, but UF2 entry was ~1/11 (that success was
+Adafruit double-reset detection). Root cause: the nRF path wrote GPREGRET=0x57
+then fell through to sys_reboot(SYS_REBOOT_WARM); with NRF_STORE_REBOOT_TYPE_GPREGRET=y
+sys_reboot writes its arg to GPREGRET[0], so WARM(0) CLOBBERED the magic.
+FIX (branch fix/gpregret-reboot): reboot via sys_reboot(0x57) — magic as the
+reboot type — plus a GPREGRET readback WRN for observability. Hardware: LEFT
+half 5/5 (immediate + settled). Right half identical fw, not yet tested.
+Lesson: don't claim "hardware-validated" from a single fluke success (PR #5 did).
+
 ## Hardware test #1 (real nRF52840 Cradio LEFT) — bug found + fixed
 - CONFIRMED on hw: CDC enumerates, 1200-baud touch IS detected + reboots, and
   running serial == bootloader serial == 8905AEEAAFB95703 (identical, no

--- a/tools/kbd-flash/README.md
+++ b/tools/kbd-flash/README.md
@@ -4,6 +4,11 @@ Flash a ZMK split keyboard over USB with **no physical reset** — plug both
 halves in, run one command, walk away. Each half gets the correct firmware
 (routed by chip id) and, optionally, its Bluetooth bonds wiped.
 
+**Status:** host-triggered reset-free bootloader entry + reflash is validated on
+real nice!nano v2 hardware — 5/5 trials on the left half (immediate and settled
+touches). Right half runs identical firmware (expected to work, not yet tested).
+The host orchestrator (`kbd-flash`) is Linux-only; on macOS use `mac_touch.sh`.
+
 This pairs a small ZMK firmware feature with a host orchestrator:
 
 - **Firmware** (`../../zmk_modules/usb-bootloader-touch/`): reboots a half into

--- a/zmk_modules/usb-bootloader-touch/src/usb_bootloader_touch.c
+++ b/zmk_modules/usb-bootloader-touch/src/usb_bootloader_touch.c
@@ -66,32 +66,41 @@ static void enter_bootloader_work(struct k_work *work)
 	LOG_WRN("1200-baud touch: rebooting into UF2 bootloader");
 
 #if IS_ENABLED(CONFIG_USB_BOOTLOADER_TOUCH_NRF_GPREGRET)
-	/* Deterministic nRF52 path: write the UF2 DFU magic to GPREGRET[0]
-	 * directly — exactly what ZMK's bootmode magic-mapper ends up doing, but
-	 * without depending on the retention boot_mode subsystem (which is not
-	 * enabled in this build). GPREGRET survives the warm/soft reset; the
-	 * Adafruit bootloader reads it on boot and enters UF2 DFU. */
+	/* nRF52: write the Adafruit UF2 DFU magic (0x57) to GPREGRET[0], which the
+	 * bootloader reads on boot. Read it back so a hardware capture proves the
+	 * write actually lands. */
 	nrf_power_gpregret_set(NRF_POWER, 0, UF2_DFU_MAGIC);
-#elif IS_ENABLED(CONFIG_RETENTION_BOOT_MODE)
-	int ret = bootmode_set(BOOT_MODE_TYPE_BOOTLOADER);
+	uint32_t rb = nrf_power_gpregret_get(NRF_POWER, 0);
 
-	if (ret < 0) {
-		LOG_ERR("bootmode_set failed (%d); not rebooting", ret);
+	LOG_WRN("GPREGRET readback=0x%02x (want 0x%02x)", (unsigned int)rb, UF2_DFU_MAGIC);
+	LOG_PANIC();
+	k_msleep(150);
+
+	/* Reboot passing the magic AS the reboot type. With
+	 * CONFIG_NRF_STORE_REBOOT_TYPE_GPREGRET=y (set in this build), sys_reboot()
+	 * writes its argument into GPREGRET[0] just before resetting — so a plain
+	 * SYS_REBOOT_WARM (0) would CLOBBER the magic we just wrote. Passing 0x57
+	 * makes that store write the magic; the direct write above covers the case
+	 * where the store is a no-op. Either way GPREGRET[0] == 0x57 at reset. */
+	sys_reboot(UF2_DFU_MAGIC);
+#elif IS_ENABLED(CONFIG_RETENTION_BOOT_MODE)
+	if (bootmode_set(BOOT_MODE_TYPE_BOOTLOADER) < 0) {
+		LOG_ERR("bootmode_set failed; not rebooting");
 		return;
 	}
+	LOG_PANIC();
+	k_msleep(150);
+	sys_reboot(SYS_REBOOT_WARM);
 #else
 	/* native_sim / unit builds: no bootloader-entry mechanism. */
 	LOG_WRN("no bootloader-entry mechanism for this target (test build)");
 	if (IS_ENABLED(CONFIG_USB_BOOTLOADER_TOUCH_TEST_NO_REBOOT)) {
 		return;
 	}
-#endif
-
-	/* Flush the decision over CDC before we drop off the bus (so the WRN line
-	 * is observable for hardware debugging), then reboot. */
 	LOG_PANIC();
 	k_msleep(150);
 	sys_reboot(SYS_REBOOT_WARM);
+#endif
 }
 
 static K_WORK_DEFINE(bl_work, enter_bootloader_work);


### PR DESCRIPTION
Follow-up to #5. Host-triggered reset-free bootloader entry was NOT actually working on hardware (detection+reboot reliable, but UF2 entry ~1/11 — that success was Adafruit double-reset detection, not our magic).

**Root cause:** the nRF path wrote `GPREGRET=0x57` then fell through to `sys_reboot(SYS_REBOOT_WARM)`. With `CONFIG_NRF_STORE_REBOOT_TYPE_GPREGRET=y`, `sys_reboot()` writes its argument into `GPREGRET[0]` just before resetting — so `WARM` (0) clobbered the magic. Bootloader saw 0 → normal fw. Affected both halves regardless of role/partner/bootloader version.

**Fix:** reboot via `sys_reboot(0x57)` (magic as the reboot type) so the store writes the magic instead of clobbering it; the direct write + a `GPREGRET readback` WRN remain for observability/diagnosis.

**Validated on real nice!nano v2:** LEFT half 5/5 trials (immediate + settled touches), each entered the UF2 bootloader reset-free and reflashed. Right half runs identical firmware (expected to work, not yet tested).

Also corrects #5's over-claim (it was merged calling this "hardware-validated" off a single fluke). `mac_touch.sh` already carries the required prime-9600→1200 termios trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)