### PR TITLE
docs: both halves validated 5/5 on hardware

### DIFF
--- a/tools/kbd-flash/BENCH.md
+++ b/tools/kbd-flash/BENCH.md
@@ -59,8 +59,8 @@ A bare `stty 1200` is a no-op change and will NOT trigger — confirmed on macOS
 
 VERIFIED ON HARDWARE (the parts native_sim could not):
 - [x] Primed 9600->1200 touch -> half reboots -> `NICENANO` mounts reset-free
-      (real GPREGRET=0x57 -> UF2 handoff). LEFT half: 5/5 trials, immediate and
-      settled. Right half: identical fw, expected to work, not yet tested.
+      (real GPREGRET=0x57 -> UF2 handoff). BOTH halves: 5/5 trials each (left
+      8905, right 32AA), immediate and settled. Validated on the full keyboard.
 - [x] Two bugs found + fixed on hardware along the way:
       1. Build had RETENTION_BOOT_MODE off -> module took #else -> bare reboot,
          magic never written (run <=27514396150).

--- a/tools/kbd-flash/PROGRESS.md
+++ b/tools/kbd-flash/PROGRESS.md
@@ -92,15 +92,16 @@ ALL GREEN). 32 host tests + 1500-trial fuzz + native_sim+usbip fw test.
 - 39 tests green. SOFTWARE COMPLETE — switching loop to long idle intervals;
   only hardware-gated bench work remains (BENCH.md).
 
-## Hardware test #2/#3 — RESOLVED, validated 5/5 (left half)
+## Hardware test #2/#3 — RESOLVED, validated 5/5 BOTH halves
 The "fix" from test #1 (direct GPREGRET write) did NOT actually work: detection +
 reboot were reliable on both halves, but UF2 entry was ~1/11 (that success was
 Adafruit double-reset detection). Root cause: the nRF path wrote GPREGRET=0x57
 then fell through to sys_reboot(SYS_REBOOT_WARM); with NRF_STORE_REBOOT_TYPE_GPREGRET=y
 sys_reboot writes its arg to GPREGRET[0], so WARM(0) CLOBBERED the magic.
 FIX (branch fix/gpregret-reboot): reboot via sys_reboot(0x57) — magic as the
-reboot type — plus a GPREGRET readback WRN for observability. Hardware: LEFT
-half 5/5 (immediate + settled). Right half identical fw, not yet tested.
+reboot type — plus a GPREGRET readback WRN for observability. Hardware: BOTH
+halves 5/5 (left 8905, right 32AA; immediate + settled). Validated on the full
+keyboard. Merged via PR #6 (fix) + #7 (this doc accuracy update).
 Lesson: don't claim "hardware-validated" from a single fluke success (PR #5 did).
 
 ## Hardware test #1 (real nRF52840 Cradio LEFT) — bug found + fixed

--- a/tools/kbd-flash/README.md
+++ b/tools/kbd-flash/README.md
@@ -5,9 +5,9 @@ halves in, run one command, walk away. Each half gets the correct firmware
 (routed by chip id) and, optionally, its Bluetooth bonds wiped.
 
 **Status:** host-triggered reset-free bootloader entry + reflash is validated on
-real nice!nano v2 hardware — 5/5 trials on the left half (immediate and settled
-touches). Right half runs identical firmware (expected to work, not yet tested).
-The host orchestrator (`kbd-flash`) is Linux-only; on macOS use `mac_touch.sh`.
+real nice!nano v2 hardware — **5/5 trials on BOTH halves** (left 8905, right
+32AA; immediate and settled touches). The host orchestrator (`kbd-flash`) is
+Linux-only; on macOS use `mac_touch.sh`.
 
 This pairs a small ZMK firmware feature with a host orchestrator:
 


### PR DESCRIPTION
Both halves (left 8905, right 32AA) now pass 5/5 reset-free bootloader-entry trials. Updates README/PROGRESS/BENCH status from left-only to full-keyboard. Docs only; follow-up to #6.