### PR TITLE
docs(kbd-flash): canonical FLASHING runbook + macOS serial-DFU/touch tooling

### DIFF
--- a/tools/kbd-flash/FLASHING.md
+++ b/tools/kbd-flash/FLASHING.md
@@ -1,0 +1,68 @@
+# Flashing the Cradio — runbook
+
+Canonical "how to flash this keyboard" guide. The keyboard is a **Cradio (Sweep)**:
+34-key Colemak-DH BLE split, two **nice!nano v2** (nRF52840) halves running ZMK.
+Left = split **central** (`cradio_left`), right = **peripheral** (`cradio_right`).
+Firmware ships the **usb-bootloader-touch** feature (PR #5/#6), so a half can be
+put into its bootloader over USB with **no physical reset**.
+
+> Cedar has **two pairs**. Identify a pair by **switch color**; identify a half by
+> its **chip serial** (= the bootloader's USB serial). Known so far — white pair:
+> left `8905AEEAAFB95703` (central), right `32AA4109F019FEAF` (peripheral). The blue
+> pair has different serials: read them fresh.
+
+## 0. Get firmware
+Built by GitHub Actions on `renxida/zmk-config` (main). Download a run's artifacts:
+```
+gh run download <run_id> -R renxida/zmk-config -D ~/kbd-fw
+# -> cradio_left-…uf2, cradio_right-…uf2, settings_reset(_touch).uf2  (+ .hex/.zip for serial DFU)
+```
+
+## 1. Identify halves (which port is which chip)
+```
+python3 tools/kbd-flash/macos/portmap.py     # prints "<chip_serial> <cu_port>"
+ioreg -p IOUSB -l -w0 | grep -iE '"USB Product Name"|"USB Serial Number"'
+```
+USB product strings tell you the mode: `Cradio L`/`Cradio R` = running cradio fw;
+`Cradio Reset` = settings_reset_touch; `nice_nano`/`nice_nano v2` (vendor "Nice
+Keyboards") = **in the bootloader**.
+
+## 2. Enter the bootloader (per half)
+- **Reset-free (preferred):** `python3 tools/kbd-flash/macos/mac_touch.py <chip_serial>`
+  (opens the CDC port, baud 9600→1200; the *change* fires the watcher → reboot to
+  bootloader). Plain `stty 1200` does **not** work on macOS.
+- **First install / no touch fw yet:** physically **double-tap** the nice!nano reset.
+
+## 3. Flash — pick ONE path
+**A. MSC drag-drop (simplest, when NICENANO mounts):**
+```
+cp ~/kbd-fw/cradio_left-…uf2 /Volumes/NICENANO/    # verify the bootloader serial == the chip first!
+```
+**B. Serial DFU (robust, macOS-mount-independent — use when NICENANO won't mount):**
+```
+python3 -m venv ~/.venv-nrfdfu && ~/.venv-nrfdfu/bin/pip install adafruit-nrfutil pyserial   # once
+python3 tools/kbd-flash/macos/serial_dfu.py <chip_serial> ~/kbd-fw/cradio_left-…uf2
+```
+(handles uf2→hex→DFU-zip and `--touch` automatically; direct DFU when already in
+the bootloader. See [macos/](macos/) and `reference-nicenano-serial-dfu` memory.)
+
+## 4. Fix split pairing (`Security failed err 2` / one half "doesn't work")
+`err 2` = `BT_SECURITY_ERR_PIN_OR_KEY_MISSING` = **mismatched BLE bonds** (common
+after reflashing one half). Fix = wipe bonds on **both** halves, then reflash:
+1. Flash **`settings_reset_touch`** to BOTH halves (erases NVS/bonds on boot; it's
+   touch-capable so still recoverable). 2. Flash `cradio_left`/`cradio_right` back.
+3. Power-cycle both → they re-bond fresh. Verify on the central's CDC log:
+   `[SUBSCRIBED]` + `security_changed … level 2` (success), and no more `err 2`.
+
+## Gotchas (learned the hard way)
+- **Don't thrash the MSC mount.** Hundreds of rapid mount/touch/DFU cycles **wedge
+  the macOS USB stack** — NICENANO stops mounting and serial DFU returns "No data
+  received". Fix = **physically replug both halves** (or reboot). Prefer serial DFU
+  to minimize mount cycles.
+- **err-2 loop blocks the touch.** A central stuck retrying a bad bond floods BLE
+  and starves USB, so the 1200-baud touch won't fire. Quiet the partner first
+  (put it in bootloader / on settings_reset).
+- **Always serial-guard the target chip** before writing (left vs right), or you'll
+  flash the wrong side and break pairing.
+- The host BLE bond (keyboard↔computer) is **separate** from the split bond; if the
+  host connection is flaky after a fix, forget+re-add the keyboard on the host.

--- a/tools/kbd-flash/macos/mac_touch.py
+++ b/tools/kbd-flash/macos/mac_touch.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Reset-free bootloader entry on macOS for usb-bootloader-touch firmware.
+
+Opens the half's USB CDC port and changes the baud 9600 -> 1200. The *change*
+to 1200 is what fires the firmware's dwDTERate watcher (plain `stty 1200` does
+NOT work on macOS, because the rate is already applied on first open -> no
+change). The half then reboots into the UF2 bootloader (NICENANO / serial DFU).
+
+Usage:
+  mac_touch.py <chip_serial|/dev/cu.usbmodemXXX>
+e.g. mac_touch.py 8905AEEAAFB95703     # by chip serial (resolves the port)
+     mac_touch.py /dev/cu.usbmodem1101 # by port
+
+NOTE: the touch will NOT fire if the half is a split central stuck in an
+err-2 bond-retry loop (BLE activity starves USB) — quiet the partner first.
+"""
+import sys, os, time, termios, select, subprocess, re
+
+def port_for_serial(ser):
+    out = subprocess.run("ioreg -r -c IOUSBHostDevice -l -w0", shell=True,
+                         capture_output=True, text=True).stdout
+    cur = None
+    for ln in out.splitlines():
+        s = re.search(r'"USB Serial Number" = "([0-9A-Fa-f]{16})"', ln)
+        c = re.search(r'"IOCalloutDevice" = "(/dev/cu\.usbmodem[0-9]+)"', ln)
+        if s: cur = s.group(1)
+        if c and cur == ser: return c.group(1)
+    return None
+
+def touch(port, hold=1.5):
+    fd = os.open(port, os.O_RDWR | os.O_NOCTTY | os.O_NONBLOCK)
+    def baud(b):
+        a = termios.tcgetattr(fd); a[4] = a[5] = b
+        termios.tcsetattr(fd, termios.TCSANOW, a)
+    baud(termios.B9600); time.sleep(0.4); baud(termios.B1200)
+    end = time.time() + hold
+    while time.time() < end:
+        r, _, _ = select.select([fd], [], [], 0.3)
+        if r:
+            try: os.read(fd, 4096)
+            except OSError: break  # bus drop == rebooting
+    try: os.close(fd)
+    except OSError: pass
+
+if __name__ == "__main__":
+    arg = sys.argv[1]
+    port = arg if arg.startswith("/dev/") else port_for_serial(arg)
+    if not port:
+        print(f"no CDC port for {arg}"); sys.exit(1)
+    print(f"touching {port} (9600->1200)...")
+    touch(port)
+    print("done — check for NICENANO mount or use serial DFU")

--- a/tools/kbd-flash/macos/portmap.py
+++ b/tools/kbd-flash/macos/portmap.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+import subprocess, re
+out = subprocess.run("ioreg -r -c IOUSBHostDevice -l -w0", shell=True, capture_output=True, text=True).stdout
+cur = None
+for ln in out.splitlines():
+    s = re.search(r'"USB Serial Number" = "([0-9A-Fa-f]{16})"', ln)
+    c = re.search(r'"IOCalloutDevice" = "(/dev/cu\.usbmodem[0-9]+)"', ln)
+    if s: cur = s.group(1)
+    if c and cur: print(cur, c.group(1))

--- a/tools/kbd-flash/macos/serial_dfu.py
+++ b/tools/kbd-flash/macos/serial_dfu.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Flash a .uf2 to a nice!nano over serial DFU on macOS — no NICENANO mount needed.
+
+Why: after many rapid NICENANO mount cycles, macOS's USB mass-storage / disk
+arbitration wedges and the volume stops mounting. Serial DFU flashes over the
+Adafruit bootloader's CDC port instead, sidestepping that entirely.
+
+Needs adafruit-nrfutil (see FLASHING.md): ~/.venv-nrfdfu/bin/adafruit-nrfutil
+Converts uf2 -> hex (uf2hex.py) -> DFU .zip (genpkg) -> `dfu serial`.
+
+Usage:
+  serial_dfu.py <chip_serial> <firmware.uf2>
+The half may be in its bootloader (direct DFU) or running a touch-capable app
+(auto-adds --touch 1200 to reset it into the bootloader first).
+"""
+import sys, os, re, subprocess, tempfile
+HERE = os.path.dirname(os.path.abspath(__file__))
+NRF = os.path.expanduser("~/.venv-nrfdfu/bin/adafruit-nrfutil")
+
+def state(ser):
+    o1 = subprocess.run("ioreg -p IOUSB -l -w0", shell=True, capture_output=True, text=True).stdout
+    prod = {}; cur = None
+    for ln in o1.splitlines():
+        p = re.search(r'"USB Product Name" = "(.*?)"', ln)
+        s = re.search(r'"USB Serial Number" = "([0-9A-Fa-f]{16})"', ln)
+        if p: cur = p.group(1)
+        if s: prod[s.group(1)] = cur
+    o2 = subprocess.run("ioreg -r -c IOUSBHostDevice -l -w0", shell=True, capture_output=True, text=True).stdout
+    port = {}; cs = None
+    for ln in o2.splitlines():
+        s = re.search(r'"USB Serial Number" = "([0-9A-Fa-f]{16})"', ln)
+        c = re.search(r'"IOCalloutDevice" = "(/dev/cu\.usbmodem[0-9]+)"', ln)
+        if s: cs = s.group(1)
+        if c and cs: port[cs] = c.group(1)
+    return prod.get(ser, ""), port.get(ser)
+
+def main():
+    ser, uf2 = sys.argv[1], sys.argv[2]
+    prod, port = state(ser)
+    if not port:
+        print(f"no CDC port for {ser} (prod={prod!r})"); sys.exit(1)
+    td = tempfile.mkdtemp()
+    hexf, zipf = f"{td}/fw.hex", f"{td}/fw.zip"
+    subprocess.run([sys.executable, f"{HERE}/uf2hex.py", uf2, hexf], check=True)
+    subprocess.run([NRF, "dfu", "genpkg", "--dev-type", "0x0052",
+                    "--application", hexf, zipf], check=True, capture_output=True)
+    # in bootloader -> direct (most reliable); running app -> --touch 1200
+    touch = [] if "nice_nano" in prod.lower() else ["--touch", "1200"]
+    print(f"serial DFU {ser} ({prod!r}) on {port}  touch={bool(touch)}")
+    r = subprocess.run([NRF, "dfu", "serial", "-pkg", zipf, "-p", port,
+                        "-b", "115200"] + touch, capture_output=True, text=True)
+    ok = "Device programmed" in (r.stdout + r.stderr)
+    print(r.stdout.strip()[-400:] if ok else (r.stdout + r.stderr)[-600:])
+    # If "No data received": host USB/CDC may be wedged from heavy cycling -> replug.
+    sys.exit(0 if ok else 2)
+
+if __name__ == "__main__":
+    main()

--- a/tools/kbd-flash/macos/uf2hex.py
+++ b/tools/kbd-flash/macos/uf2hex.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+# Minimal UF2 -> Intel HEX converter (preserves target addresses).
+import sys, struct
+inp, outp = sys.argv[1], sys.argv[2]
+data = open(inp, 'rb').read()
+mem = {}
+for i in range(0, len(data), 512):
+    blk = data[i:i+512]
+    if len(blk) < 512: break
+    m0, m1 = struct.unpack('<II', blk[0:8])
+    if m0 != 0x0A324655 or m1 != 0x9E5D5157: continue
+    flags, addr, plen = struct.unpack('<III', blk[8:20])
+    for j, b in enumerate(blk[32:32+plen]): mem[addr+j] = b
+addrs = sorted(mem)
+lines = []
+def emit(rtype, off, payload):
+    rec = bytes([len(payload), (off>>8)&0xff, off&0xff, rtype]) + payload
+    chk = (-sum(rec)) & 0xff
+    lines.append(':' + (rec + bytes([chk])).hex().upper())
+cur_upper = None; idx = 0; n = len(addrs)
+while idx < n:
+    start = addrs[idx]; row = [mem[start]]
+    while (idx+len(row) < n and addrs[idx+len(row)] == start+len(row)
+           and len(row) < 16 and (start>>16) == ((start+len(row))>>16)):
+        row.append(mem[addrs[idx+len(row)]])
+    upper = (start>>16)&0xffff
+    if upper != cur_upper:
+        emit(4, 0, struct.pack('>H', upper)); cur_upper = upper
+    emit(0, start&0xffff, bytes(row)); idx += len(row)
+emit(1, 0, b'')
+open(outp, 'w').write('\n'.join(lines)+'\n')
+lo, hi = addrs[0], addrs[-1]
+print(f"wrote {outp}: {len(mem)} bytes, range 0x{lo:05X}-0x{hi:05X}, {len(lines)} hex records")


### PR DESCRIPTION
Adds tools/kbd-flash/FLASHING.md — the entry-point guide for flashing the
Cradio on any machine: half identification, reset-free bootloader entry
(usb-bootloader-touch), MSC vs serial-DFU flashing, the settings_reset
bond-fix procedure, and the hard-won gotchas (macOS USB-stack wedge from
mount thrashing; err-2 loop starving the touch).

macOS helpers under tools/kbd-flash/macos/: mac_touch.py (9600->1200 touch),
serial_dfu.py (flash a uf2 over the bootloader CDC, mount-independent),
plus uf2hex.py + portmap.py.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
