### PR TITLE
Touch-capable settings_reset, boot-guard (default-off test image), CI DFU artifacts

### DIFF
--- a/.github/scripts/uf2_to_hex.py
+++ b/.github/scripts/uf2_to_hex.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Convert a UF2 image to Intel HEX (stdlib only).
+
+Usage: uf2_to_hex.py <in.uf2> <out.hex>
+
+UF2 is 512-byte blocks; each block header carries a target flash address and a
+payload. We emit Intel HEX with Extended Linear Address (type 04) records for
+the >64 KiB nRF52840 flash addresses, never crossing a 64 KiB boundary within a
+data record.
+"""
+import struct
+import sys
+
+UF2_MAGIC0 = 0x0A324655
+UF2_MAGIC1 = 0x9E5D5157
+
+
+def _ihex(rectype, addr16, data):
+    rec = bytes([len(data), (addr16 >> 8) & 0xFF, addr16 & 0xFF, rectype]) + data
+    chk = (-sum(rec)) & 0xFF
+    return ":" + rec.hex().upper() + format(chk, "02X")
+
+
+def uf2_to_hex(uf2_path, hex_path):
+    blob = open(uf2_path, "rb").read()
+    if len(blob) % 512 != 0:
+        raise ValueError(f"{uf2_path}: size {len(blob)} not a multiple of 512")
+
+    lines = []
+    cur_upper = None
+    for i in range(0, len(blob), 512):
+        blk = blob[i:i + 512]
+        magic0, magic1, _flags, addr, size, _no, _num, _fam = struct.unpack(
+            "<IIIIIIII", blk[:32])
+        if magic0 != UF2_MAGIC0 or magic1 != UF2_MAGIC1:
+            continue  # not a UF2 block
+        if size > 476:
+            raise ValueError(f"{uf2_path}: bad payload size {size}")
+        payload = blk[32:32 + size]
+
+        off = 0
+        while off < size:
+            a = addr + off
+            upper = a >> 16
+            if upper != cur_upper:
+                lines.append(_ihex(0x04, 0,
+                                   bytes([(upper >> 8) & 0xFF, upper & 0xFF])))
+                cur_upper = upper
+            room = 0x10000 - (a & 0xFFFF)            # stay within this 64 KiB
+            chunk = payload[off:off + min(16, room)]
+            lines.append(_ihex(0x00, a & 0xFFFF, chunk))
+            off += len(chunk)
+
+    lines.append(_ihex(0x01, 0, b""))               # EOF
+    with open(hex_path, "w") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        sys.exit("usage: uf2_to_hex.py <in.uf2> <out.hex>")
+    uf2_to_hex(sys.argv[1], sys.argv[2])

--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -21,6 +21,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout (for the uf2->hex script)
+        uses: actions/checkout@v4
       - name: Download built firmware
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -13,3 +13,34 @@ jobs:
     uses: renxida/zmk-actions/.github/workflows/build-user-config.yml@main
     with:
       toolchain: zephyr
+
+  # Emit serial-DFU artifacts (.hex, and an adafruit-nrfutil .zip if it builds)
+  # alongside each .uf2 so macOS-mount-independent flashing needs no local
+  # uf2->hex conversion.
+  dfu-artifacts:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download built firmware
+        uses: actions/download-artifact@v4
+        with:
+          name: firmware
+          path: fw
+      - name: Convert .uf2 -> .hex (+ .zip)
+        run: |
+          set -e
+          python3 -m pip install --quiet adafruit-nrfutil || echo "nrfutil install failed; .zip will be skipped"
+          mkdir -p dfu
+          for u in fw/*.uf2; do
+            [ -e "$u" ] || continue
+            base=$(basename "$u" .uf2)
+            python3 .github/scripts/uf2_to_hex.py "$u" "dfu/$base.hex"
+            adafruit-nrfutil dfu genpkg --dev-type 0x0052 --application "dfu/$base.hex" "dfu/$base.zip" \
+              || echo "genpkg failed for $base (.hex still produced)"
+          done
+          ls -l dfu
+      - name: Upload DFU artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-dfu
+          path: dfu/

--- a/build.yaml
+++ b/build.yaml
@@ -9,5 +9,12 @@ include:
     shield: cradio_right
     snippet: zmk-usb-logging
     cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch_right.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+  # Touch-capable settings_reset: erases NVS (clears stale BT bonds) then comes
+  # up USB-recoverable (CDC + 1200-baud touch watcher), BLE off. The plain
+  # non-recoverable settings_reset is intentionally NOT built — per the safety
+  # model every artifact must be touch-recoverable.
   - board: nice_nano_v2
     shield: settings_reset
+    snippet: zmk-usb-logging
+    cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch_reset.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+    artifact-name: settings_reset_touch

--- a/build.yaml
+++ b/build.yaml
@@ -18,3 +18,9 @@ include:
     snippet: zmk-usb-logging
     cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch_reset.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
     artifact-name: settings_reset_touch
+  # SEPARATE boot-guard test image (boot guard is default-off in daily fw).
+  - board: nice_nano_v2
+    shield: cradio_left
+    snippet: zmk-usb-logging
+    cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch_bootguard.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+    artifact-name: cradio_left_bootguard_test

--- a/config/bootloader_touch_bootguard.conf
+++ b/config/bootloader_touch_bootguard.conf
@@ -1,0 +1,12 @@
+# SEPARATE boot-guard TEST image (cradio_left + boot guard ENABLED).
+# The boot guard is default-off in the daily firmware; this image exists only to
+# validate the failsafe on hardware. Lower COUNT (5) so it's easy to trigger by
+# tapping reset rapidly. Recoverable via touch like any other touch image.
+CONFIG_USB_BOOTLOADER_TOUCH=y
+CONFIG_HWINFO=y
+CONFIG_USB_DEVICE_SN="0123456789ABCDEF"
+CONFIG_USB_DEVICE_PRODUCT="Cradio L BG"
+
+CONFIG_USB_BOOTLOADER_TOUCH_BOOT_GUARD=y
+CONFIG_USB_BOOTLOADER_TOUCH_BOOT_GUARD_COUNT=5
+CONFIG_USB_BOOTLOADER_TOUCH_BOOT_GUARD_WINDOW_MS=10000

--- a/config/bootloader_touch_reset.conf
+++ b/config/bootloader_touch_reset.conf
@@ -1,0 +1,13 @@
+# Touch + identity config for the settings_reset_touch build (referenced via
+# EXTRA_CONF_FILE). Makes the settings-wipe image USB-recoverable: it erases NVS
+# at POST_KERNEL, then comes up with USB CDC + the 1200-baud touch watcher and
+# idles there (BLE is already disabled by settings_reset.conf, so nothing can
+# hang before the watcher is live).
+CONFIG_USB_BOOTLOADER_TOUCH=y
+
+# Running USB serial = nRF FICR.DEVICEID, so the host can still identify it.
+CONFIG_HWINFO=y
+CONFIG_USB_DEVICE_SN="0123456789ABCDEF"
+
+# Distinct product string so `kbd-flash list` shows it's the reset image.
+CONFIG_USB_DEVICE_PRODUCT="Cradio Reset"

--- a/tools/kbd-flash/REFERENCE.md
+++ b/tools/kbd-flash/REFERENCE.md
@@ -1,0 +1,127 @@
+# Reference: ZMK bootloader entry, USB CDC, split BT bonds (source-cited)
+
+Background for the usb-bootloader-touch + kbd-flash project. nice!nano v2
+(nRF52840), ZMK on Zephyr 4.1, Adafruit nRF52 UF2 bootloader. Line numbers are
+from each repo's `main` at research time and may drift slightly.
+
+## 1. `settings_reset` — what it actually does
+`CONFIG_ZMK_SETTINGS_RESET_ON_START=y` registers `zmk_settings_erase` as a
+`SYS_INIT(POST_KERNEL, prio 60)`. It opens the settings flash partition, erases
+it, closes it, and **returns** — it does NOT reboot/halt/loop; the system keeps
+booting normally afterward.
+- `app/src/settings/reset_settings_on_start.c` (the SYS_INIT)
+- `app/src/settings/reset_settings_nvs.c` (`zmk_settings_erase`: flash_area_open
+  → flash_area_erase → flash_area_close → return)
+- The `settings_reset` shield (`app/boards/shields/settings_reset/`) also sets
+  `CONFIG_ZMK_BLE=n` (comment: "so splits don't try to re-pair until normal
+  firmware is flashed") + `CONFIG_ZMK_DISPLAY=n` + a mock kscan.
+
+**Consequence:** a settings_reset build is just a minimal ZMK image that wipes
+NVS once early, then idles. Adding USB CDC + the touch watcher makes it sit
+there touch-recoverable, with no BLE to hang — the basis of
+`settings_reset_touch`.
+
+## 2. nRF52 UF2 bootloader entry (GPREGRET / boot-mode)
+The Adafruit bootloader enters UF2 DFU when it reads magic `0x57`
+(`DFU_MAGIC_UF2_RESET`) from `NRF_POWER->GPREGRET[0]` at boot.
+- ZMK `&bootloader` behavior: `app/src/behaviors/behavior_reset.c` →
+  `bootmode_set(BOOT_MODE_TYPE_BOOTLOADER)` then `sys_reboot(SYS_REBOOT_WARM)`
+  (when `CONFIG_RETENTION_BOOT_MODE`).
+- The magic mapper that ultimately writes `0x57` to GPREGRET[0]:
+  `app/src/boot/bootmode_to_magic_mapper.c`, value from
+  `CONFIG_ZMK_BOOTMODE_BOOTLOADER_MAGIC_VALUE` (0x57 for
+  `ADAFRUIT_NRF52`, `app/src/boot/Kconfig.defaults`), backed by the `gpregret1`
+  retention node (`app/dts/common/nordic/nrf52840_uf2_boot_mode.dtsi`).
+- HAL: `nrf_power_gpregret_set(NRF_POWER, 0, 0x57)` /
+  `nrf_power_gpregret_get(NRF_POWER, 0)` (nrfx `hal/nrf_power.h`). GPREGRET
+  survives a warm/soft reset (NVIC SystemReset), but NOT power-on/pin/brownout.
+
+**The clobber bug we hit:** with `CONFIG_NRF_STORE_REBOOT_TYPE_GPREGRET=y`,
+`sys_reboot(kind)` writes `kind` into GPREGRET[0] right before resetting. So
+writing `0x57` then calling `sys_reboot(SYS_REBOOT_WARM)` (=0) **clobbers** the
+magic to 0 → bootloader sees nothing → normal fw. Fix: `sys_reboot(0x57)` (magic
+as the reboot type). Validated 5/5 on both halves. See `usb_bootloader_touch.c`.
+
+## 3. USB CDC + the 1200-baud touch
+- `CONFIG_ZMK_USB_LOGGING=y` (via the `zmk-usb-logging` snippet) brings up a USB
+  CDC ACM port (selects `USB_CDC_ACM`, `UART_LINE_CTRL`, etc.; ZMK `app/Kconfig`).
+  The snippet's CDC node label is `snippet_zmk_usb_logging_uart`.
+- Detection is event-driven: `cdc_acm_dte_rate_callback_set()` fires the
+  registered callback on the host's SetLineCoding **rate change**
+  (`subsys/usb/device/class/cdc_acm.c`, gated by
+  `CONFIG_CDC_ACM_DTE_RATE_CALLBACK_SUPPORT`). We trigger on rate == 1200.
+- The nRF52840 Adafruit bootloader does NOT do baud-triggered DFU itself (the
+  DTR-auto-reset path is nRF52832-only) — that's why the touch is reproduced in
+  the ZMK app. Host-triggered bootloader-over-USB does not exist upstream
+  (ZMK issue #2635, closed "not planned").
+- HOST GOTCHA: the callback fires on a *change* to 1200. The OS may set the rate
+  on first open, so a bare `stty 1200` is a no-op change and won't fire. Prime
+  to 9600 then 1200 within one open (see `mac_touch.sh`, `LinuxPlatform.touch_1200`).
+
+## 4. USB serial = chip id
+With `CONFIG_HWINFO=y` and a `CONFIG_USB_DEVICE_SN` placeholder, Zephyr overwrites
+the serial-number string descriptor from `hwinfo_get_device_id()` at USB init
+(`subsys/usb/device/usb_descriptor.c`, `usb_fix_ascii_sn_string_descriptor`).
+On nRF52840 that's the FICR.DEVICEID. The Adafruit bootloader independently
+exposes the same FICR.DEVICEID as its USB serial (`Adafruit_nRF52_Bootloader
+src/usb/usb_desc.c`) — confirmed byte-identical on hardware (e.g.
+`8905AEEAAFB95703`). kbd-flash uses this only for calibration/identity, not for
+cross-mode matching.
+
+## 5. Split BT bonds + `err 2` (the partner-not-working cause)
+`<err> zmk: Security failed: <addr> (random) level 1 err 2` ==
+`BT_SECURITY_ERR_PIN_OR_KEY_MISSING` (value 2 in `bt_security_err`,
+`include/zephyr/bluetooth/conn.h`). It is logged by the **peripheral**
+(`app/src/split/bluetooth/peripheral.c` `security_changed`, ~L127) — so a log
+showing it is the peripheral's console, not the central's.
+
+**Why:** the split link is encrypted implicitly — the split GATT characteristics
++ CCCs are `BT_GATT_PERM_*_ENCRYPT` (`app/src/split/bluetooth/service.c`), so when
+the central subscribes, the host auto-initiates SMP encryption using the stored
+LTK. A bond is a **matched key pair, one record per side**. If only one half was
+wiped/reflashed, the half that still has the LTK requests encryption and the
+wiped half can't supply it → err 2 → the central never reaches `BT_SECURITY_L2`
+(`central.c` gates work on `bt_conn_get_security >= L2`), tears down, rescans,
+and loops (the "subscribe → err 2 → unsubscribe → retry" you saw).
+
+**Storage:** bonds persist via `CONFIG_BT_SETTINGS` (ZMK `imply BT_SETTINGS`),
+written by `subsys/bluetooth/host/keys.c` (`bt_keys_store`/`bt_keys_clear` →
+`bt_settings_{store,delete}_keys`) into the NVS `storage_partition`
+(nice_nano.dts `partition@ec000`, 32 KiB @ 0xEC000; Zephyr settings defaults to
+the partition labeled `storage`). Erasing that partition (what
+`zmk_settings_erase` does) removes the bonds.
+
+**Why BOTH halves:** wiping one side leaves the other with a stale key with no
+counterpart → still err 2. Both must be cleared so the next connection has no
+key on either side → fresh SMP pairing → new matched LTK pair stored on both.
+The settings_reset image disables BLE precisely so the halves don't re-bond
+asymmetrically before both are wiped.
+
+**Re-bond (automatic):** after both are cleared and reflashed with real fw,
+peripheral advertises (no bonded central), central scans/connects/subscribes,
+host does a fresh LE Secure Connections pairing, both store the new bond
+(`peripheral.c` `pairing_complete` → `is_bonded`). Power-cycle both together;
+no host pairing UI needed. (ZMK also has `CONFIG_ZMK_BLE_CLEAR_BONDS_ON_START`
++ `zmk_ble_clear_all_bonds()` as a lighter alternative to a full NVS wipe.)
+Refs: zmk.dev/docs/troubleshooting/connection-issues, features/split-keyboards.
+
+## 6. Boot-count failsafe (`boot_guard.c`)
+A `__noinit` counter (survives warm reset, garbage on power-on, magic-validated)
+increments each boot; staying up past `WINDOW_MS` clears it via delayed work, so
+only RAPID consecutive reboots accumulate. `COUNT` reboots within the window →
+`GPREGRET=0x57` + `sys_reboot(0x57)`. Defaults 8 / 10 s, nRF52-only.
+Catches: crash/reboot loops + a manual reset-tap escape hatch.
+Does NOT catch: a single hang (no reboot) or BLE-load starvation of a *running*
+firmware — for that, `settings_reset_touch` (BLE off) is the guaranteed image.
+
+## 7. Recoverability model (what sim covers)
+- Sim (native_sim + usbip) proves: USB CDC enumerates, the 1200-baud change
+  fires the watcher, and an early POST_KERNEL erase (mirrors `zmk_settings_erase`)
+  doesn't strand the device before CDC + watcher come up.
+- Sim CANNOT cover: the GPREGRET→UF2 handoff, RAM-retention across reboots
+  (boot guard), or real BLE-load timing — those are hardware-only. The
+  GPREGRET→UF2 path is hardware-validated separately (5/5).
+- Observed robustness lesson: a central in the err-2 retry loop starves USB so
+  the touch won't even fire; quieting the partner (BLE off / in bootloader)
+  restores it. Mitigation = bring USB up before/independent of BLE + prefer the
+  BLE-off settings_reset_touch image for recovery.

--- a/zmk_modules/usb-bootloader-touch/CMakeLists.txt
+++ b/zmk_modules/usb-bootloader-touch/CMakeLists.txt
@@ -4,4 +4,5 @@
 if(CONFIG_USB_BOOTLOADER_TOUCH)
   zephyr_library()
   zephyr_library_sources(src/usb_bootloader_touch.c)
+  zephyr_library_sources_ifdef(CONFIG_USB_BOOTLOADER_TOUCH_BOOT_GUARD src/boot_guard.c)
 endif()

--- a/zmk_modules/usb-bootloader-touch/Kconfig
+++ b/zmk_modules/usb-bootloader-touch/Kconfig
@@ -29,12 +29,16 @@ config USB_BOOTLOADER_TOUCH_NRF_GPREGRET
 config USB_BOOTLOADER_TOUCH_BOOT_GUARD
 	bool "Boot-count failsafe: N rapid reboots -> UF2 bootloader"
 	depends on SOC_COMPATIBLE_NRF52X
-	default y
+	default n
 	help
 	  If the firmware reboots COUNT times within WINDOW_MS (a crash loop, or
 	  the user tapping reset), enter the UF2 bootloader so the device stays
 	  recoverable over USB even if a future image is broken. Catches reboot
 	  loops, NOT a single hang or BLE-load starvation of a running firmware.
+
+	  Default OFF: it runs at every boot and is not yet hardware-validated, so
+	  it is kept OUT of the daily cradio firmware and shipped only in a separate
+	  boot-guard test image (see build.yaml). Enable explicitly to test it.
 
 if USB_BOOTLOADER_TOUCH_BOOT_GUARD
 

--- a/zmk_modules/usb-bootloader-touch/Kconfig
+++ b/zmk_modules/usb-bootloader-touch/Kconfig
@@ -26,6 +26,28 @@ config USB_BOOTLOADER_TOUCH_NRF_GPREGRET
 	  boot_mode subsystem. This is what the mapper ultimately does and is
 	  deterministic even when CONFIG_RETENTION_BOOT_MODE is not enabled.
 
+config USB_BOOTLOADER_TOUCH_BOOT_GUARD
+	bool "Boot-count failsafe: N rapid reboots -> UF2 bootloader"
+	depends on SOC_COMPATIBLE_NRF52X
+	default y
+	help
+	  If the firmware reboots COUNT times within WINDOW_MS (a crash loop, or
+	  the user tapping reset), enter the UF2 bootloader so the device stays
+	  recoverable over USB even if a future image is broken. Catches reboot
+	  loops, NOT a single hang or BLE-load starvation of a running firmware.
+
+if USB_BOOTLOADER_TOUCH_BOOT_GUARD
+
+config USB_BOOTLOADER_TOUCH_BOOT_GUARD_COUNT
+	int "Reboots within the window that trigger the failsafe"
+	default 8
+
+config USB_BOOTLOADER_TOUCH_BOOT_GUARD_WINDOW_MS
+	int "Window (ms): staying up this long clears the boot count"
+	default 10000
+
+endif # USB_BOOTLOADER_TOUCH_BOOT_GUARD
+
 config USB_BOOTLOADER_TOUCH_TEST_NO_REBOOT
 	bool "Detect-only (do not reboot) — for native_sim/unit tests"
 	default n

--- a/zmk_modules/usb-bootloader-touch/src/boot_guard.c
+++ b/zmk_modules/usb-bootloader-touch/src/boot_guard.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 Cedar Ren
+ * SPDX-License-Identifier: MIT
+ *
+ * Boot-count failsafe: if the firmware reboots COUNT times within WINDOW_MS
+ * (a crash loop, or the user deliberately tapping reset), enter the UF2
+ * bootloader so the device is always recoverable over USB — even if a future
+ * image is broken in a way the touch watcher can't reach.
+ *
+ * Mechanism: a __noinit counter in RAM survives a warm/soft reset (NVIC reset
+ * keeps RAM) but is garbage after power-on; a magic field distinguishes the two.
+ * Each boot increments the counter and, if we stay up past WINDOW_MS, a delayed
+ * work clears it — so only RAPID consecutive reboots accumulate toward COUNT.
+ *
+ * NOTE: this catches reboot LOOPS, not a single hang and not BLE-load
+ * starvation of a still-running firmware (for that, settings_reset_touch with
+ * BLE off is the guaranteed-recoverable image). nRF52 only; uses the same
+ * GPREGRET=0x57 + sys_reboot(magic) path as the touch watcher.
+ */
+
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <hal/nrf_power.h>
+
+LOG_MODULE_REGISTER(boot_guard, CONFIG_USB_BOOTLOADER_TOUCH_LOG_LEVEL);
+
+#define BG_MAGIC      0x42477561U /* 'BGua' — validates the __noinit struct */
+#define UF2_DFU_MAGIC 0x57U
+
+struct boot_guard_state {
+	uint32_t magic;
+	uint32_t count;
+};
+
+static __noinit struct boot_guard_state bg;
+
+/* Pure predicate, exposed for host-native unit testing. */
+bool boot_guard_should_failsafe(uint32_t count, uint32_t threshold)
+{
+	return count >= threshold;
+}
+
+static void bg_clear(struct k_work *work)
+{
+	ARG_UNUSED(work);
+	bg.count = 0;
+	LOG_DBG("boot guard: stayed up past window; count cleared");
+}
+static K_WORK_DELAYABLE_DEFINE(bg_clear_work, bg_clear);
+
+static int boot_guard_init(void)
+{
+	if (bg.magic != BG_MAGIC) {
+		/* Power-on (or post-DFU): __noinit RAM is undefined -> start fresh. */
+		bg.magic = BG_MAGIC;
+		bg.count = 0;
+	}
+
+	bg.count++;
+	LOG_INF("boot guard: boot #%u (failsafe at %u within %u ms)", bg.count,
+		(unsigned int)CONFIG_USB_BOOTLOADER_TOUCH_BOOT_GUARD_COUNT,
+		(unsigned int)CONFIG_USB_BOOTLOADER_TOUCH_BOOT_GUARD_WINDOW_MS);
+
+	if (boot_guard_should_failsafe(bg.count,
+				       CONFIG_USB_BOOTLOADER_TOUCH_BOOT_GUARD_COUNT)) {
+		LOG_WRN("boot guard: %u rapid reboots -> entering UF2 bootloader",
+			bg.count);
+		bg.count = 0;
+		nrf_power_gpregret_set(NRF_POWER, 0, UF2_DFU_MAGIC);
+		LOG_PANIC();
+		k_msleep(50);
+		sys_reboot(UF2_DFU_MAGIC);
+	}
+
+	k_work_schedule(&bg_clear_work,
+			K_MSEC(CONFIG_USB_BOOTLOADER_TOUCH_BOOT_GUARD_WINDOW_MS));
+	return 0;
+}
+
+SYS_INIT(boot_guard_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);

--- a/zmk_modules/usb-bootloader-touch/tests/native_sim/run_test.sh
+++ b/zmk_modules/usb-bootloader-touch/tests/native_sim/run_test.sh
@@ -63,10 +63,18 @@ for _ in $(seq 1 16); do grep -q "1200-baud touch detected" "$RUNLOG" && { TRIG=
 exec 3>&-
 
 echo "== assert =="
-if [ "$TRIG" = 1 ]; then
-  echo "PASS: watcher detected 1200-baud touch and scheduled bootloader"
-  grep "touch detected\|entering UF2\|would enter" "$RUNLOG" | tail -3
-  exit 0
-else
+if [ "$TRIG" != 1 ]; then
   echo "FAIL: no trigger in log"; tail -10 "$RUNLOG"; exit 1
 fi
+echo "PASS: watcher detected 1200-baud touch and scheduled bootloader"
+grep "touch detected\|entering UF2\|would enter" "$RUNLOG" | tail -3
+
+# RECOVERABILITY contract: an early POST_KERNEL erase (mirrors zmk_settings_erase)
+# ran at boot, yet CDC enumerated and the watcher still fired. This is the
+# property that makes settings_reset_touch safe to flash.
+if grep -q "mock: settings erased" "$RUNLOG"; then
+  echo "PASS: recoverability — early POST_KERNEL erase ran, CDC+touch still live"
+else
+  echo "FAIL: recoverability — early erase init did not run (compiled out?)"; exit 1
+fi
+exit 0

--- a/zmk_modules/usb-bootloader-touch/tests/native_sim/src/main.c
+++ b/zmk_modules/usb-bootloader-touch/tests/native_sim/src/main.c
@@ -5,10 +5,24 @@
  * script can observe it).
  */
 #include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include <zephyr/usb/usb_device.h>
 #include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
+
+/*
+ * Recoverability check (mirrors ZMK's settings_reset): an early POST_KERNEL
+ * init that "erases" and RETURNS must not strand the device — USB CDC + the
+ * touch watcher must still come up afterwards. Same init level/priority (60)
+ * as zmk_settings_erase. If this broke the touch path, run_test.sh would fail.
+ */
+static int mock_settings_erase(void)
+{
+	LOG_WRN("mock: settings erased at POST_KERNEL (recoverability check)");
+	return 0;
+}
+SYS_INIT(mock_settings_erase, POST_KERNEL, 60);
 
 int main(void)
 {


### PR DESCRIPTION
Mainlines the recoverability + BT-bond-fix work.

## Firmware
- **settings_reset_touch**: the settings-wipe image (clears stale split BT bonds — the err-2 PIN_OR_KEY_MISSING cause) now comes up USB-recoverable. settings_reset erases NVS at POST_KERNEL then continues boot with BLE off; adding zmk-usb-logging + the touch watcher = wipe then idle touch-recoverable. Hardware-proven recoverable. Replaces the plain non-recoverable settings_reset (safety model: every artifact is touch-recoverable).
- **Boot-count failsafe** (`boot_guard.c`): N rapid reboots within a window -> UF2 bootloader. **Default OFF** (runs every boot, not yet hw-validated) — shipped only as a separate `cradio_left_bootguard_test` image, NOT in the daily cradio fw.

## CI
- `dfu-artifacts` job emits per-image `.hex` (stdlib `uf2_to_hex.py`, byte-verified round-trip) + adafruit-nrfutil `.zip`, uploaded as `firmware-dfu` — serial DFU needs no local uf2->hex.

## Tests/docs
- native_sim recoverability contract (early POST_KERNEL erase + CDC/touch still live).
- `REFERENCE.md`: source-cited (settings_reset, GPREGRET/boot-mode + WARM-clobber, CDC touch, USB-serial=chip-id, split bonds/err2/NVS, boot guard).

All builds + dfu job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)