### PR TITLE
feat: per-pair named builds — Altair (white) + Vega (blue)

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,14 +1,33 @@
 # This file generates the GitHub Actions matrix.
+# Two named pairs (distinct CONFIG_ZMK_KEYBOARD_NAME so the host sees them
+# apart): "Altair" (white switches) and "Vega" (blue switches). Cross-pairing
+# is prevented operationally by pairing each set in isolation — bonds are
+# address-locked once formed (see tools/kbd-flash/FLASHING.md), so no unique
+# split UUID is needed.
 ---
 include:
+  # --- Altair pair (white switches) ---
   - board: nice_nano_v2
     shield: cradio_left
     snippet: zmk-usb-logging
-    cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch_left.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+    cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/pair_altair_left.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+    artifact-name: altair_left
   - board: nice_nano_v2
     shield: cradio_right
     snippet: zmk-usb-logging
-    cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch_right.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+    cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/pair_altair_right.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+    artifact-name: altair_right
+  # --- Vega pair (blue switches) ---
+  - board: nice_nano_v2
+    shield: cradio_left
+    snippet: zmk-usb-logging
+    cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/pair_vega_left.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+    artifact-name: vega_left
+  - board: nice_nano_v2
+    shield: cradio_right
+    snippet: zmk-usb-logging
+    cmake-args: -DZMK_EXTRA_MODULES=${GITHUB_WORKSPACE}/zmk_modules/usb-bootloader-touch -DEXTRA_CONF_FILE=${GITHUB_WORKSPACE}/config/pair_vega_right.conf -DEXTRA_DTC_OVERLAY_FILE=${GITHUB_WORKSPACE}/config/bootloader_touch.overlay
+    artifact-name: vega_right
   # Touch-capable settings_reset: erases NVS (clears stale BT bonds) then comes
   # up USB-recoverable (CDC + 1200-baud touch watcher), BLE off. The plain
   # non-recoverable settings_reset is intentionally NOT built — per the safety

--- a/config/pair_altair_left.conf
+++ b/config/pair_altair_left.conf
@@ -1,0 +1,7 @@
+# Altair pair — Altair L half. Self-contained per-build conf (single EXTRA_CONF_FILE).
+CONFIG_USB_BOOTLOADER_TOUCH=y
+CONFIG_HWINFO=y
+CONFIG_USB_DEVICE_SN="0123456789ABCDEF"
+CONFIG_USB_DEVICE_PRODUCT="Altair L"
+# Per-pair BLE/keyboard name → distinct device name to the host.
+CONFIG_ZMK_KEYBOARD_NAME="Altair"

--- a/config/pair_altair_right.conf
+++ b/config/pair_altair_right.conf
@@ -1,0 +1,7 @@
+# Altair pair — Altair R half. Self-contained per-build conf (single EXTRA_CONF_FILE).
+CONFIG_USB_BOOTLOADER_TOUCH=y
+CONFIG_HWINFO=y
+CONFIG_USB_DEVICE_SN="0123456789ABCDEF"
+CONFIG_USB_DEVICE_PRODUCT="Altair R"
+# Per-pair BLE/keyboard name → distinct device name to the host.
+CONFIG_ZMK_KEYBOARD_NAME="Altair"

--- a/config/pair_vega_left.conf
+++ b/config/pair_vega_left.conf
@@ -1,0 +1,7 @@
+# Vega pair — Vega L half. Self-contained per-build conf (single EXTRA_CONF_FILE).
+CONFIG_USB_BOOTLOADER_TOUCH=y
+CONFIG_HWINFO=y
+CONFIG_USB_DEVICE_SN="0123456789ABCDEF"
+CONFIG_USB_DEVICE_PRODUCT="Vega L"
+# Per-pair BLE/keyboard name → distinct device name to the host.
+CONFIG_ZMK_KEYBOARD_NAME="Vega"

--- a/config/pair_vega_right.conf
+++ b/config/pair_vega_right.conf
@@ -1,0 +1,7 @@
+# Vega pair — Vega R half. Self-contained per-build conf (single EXTRA_CONF_FILE).
+CONFIG_USB_BOOTLOADER_TOUCH=y
+CONFIG_HWINFO=y
+CONFIG_USB_DEVICE_SN="0123456789ABCDEF"
+CONFIG_USB_DEVICE_PRODUCT="Vega R"
+# Per-pair BLE/keyboard name → distinct device name to the host.
+CONFIG_ZMK_KEYBOARD_NAME="Vega"


### PR DESCRIPTION
Each pair builds cradio_left/right with a distinct CONFIG_ZMK_KEYBOARD_NAME
(and matching USB product string) so the host sees them apart. No unique
split UUID: cross-pairing is avoided by pairing each set in isolation (bonds
are address-locked once formed). Keeps settings_reset_touch + bootguard test.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
