### PR TITLE
Split battery: central proxies right-half battery level

### DIFF
--- a/config/pair_altair_left.conf
+++ b/config/pair_altair_left.conf
@@ -9,3 +9,8 @@ CONFIG_ZMK_KEYBOARD_NAME="Altair"
 # force-overrides any stale NVS-persisted name on reflash.
 CONFIG_ZMK_BLE_NAME_PROFILE=y
 CONFIG_BT_DEVICE_NAME_MAX=28
+# Split battery: central fetches the peripheral (right half) battery over the
+# split link and re-exposes it as an extra BLE Battery Service so hosts/tools
+# can read the right half's level (central-only; right half reports by default).
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING=y
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_PROXY=y

--- a/config/pair_vega_left.conf
+++ b/config/pair_vega_left.conf
@@ -9,3 +9,8 @@ CONFIG_ZMK_KEYBOARD_NAME="Vega"
 # force-overrides any stale NVS-persisted name on reflash.
 CONFIG_ZMK_BLE_NAME_PROFILE=y
 CONFIG_BT_DEVICE_NAME_MAX=28
+# Split battery: central fetches the peripheral (right half) battery over the
+# split link and re-exposes it as an extra BLE Battery Service so hosts/tools
+# can read the right half's level (central-only; right half reports by default).
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING=y
+CONFIG_ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_PROXY=y

--- a/tools/kbd-flash/macos/kbd_doctor.py
+++ b/tools/kbd-flash/macos/kbd_doctor.py
@@ -201,8 +201,11 @@ async def _battery(name, secs):
             for svc in cli.services:
                 for ch in svc.characteristics:
                     if ch.uuid.lower() == BAS_LEVEL_UUID and "read" in ch.properties:
-                        val = await cli.read_gatt_char(ch.uuid)
-                        results.append((svc.handle, int(val[0])))
+                        # read by the characteristic OBJECT, not the UUID string:
+                        # split-battery exposes >1 BAS (0x2A19), so the UUID is
+                        # ambiguous and bleak requires the handle/object.
+                        val = await cli.read_gatt_char(ch)
+                        results.append((ch.handle, int(val[0])))
             return (nm, addr, results), None
     except Exception as e:
         return None, f"connect/read failed for {nm} ({addr}): {e!r}"
@@ -222,8 +225,12 @@ def cmd_battery(args):
         print(f"  connected to {nm} ({addr}) but no readable Battery Level char "
               f"(BAS absent or encryption-gated)")
         return
-    for handle, pct in levels:
-        print(f"  {nm}: battery {pct}%  (service handle {handle})")
+    levels.sort()  # by handle; the lower-handle BAS is the central's own
+    for i, (handle, pct) in enumerate(levels):
+        who = "central/left" if i == 0 else f"peripheral #{i} (proxied)"
+        print(f"  {nm}: battery {pct}%  ({who}, char handle {handle})")
+    if len(levels) > 1:
+        print(f"  ({len(levels)} Battery Service instances — split-battery proxy is working)")
     print("  note: % is a voltage estimate; reads high while on USB power.")
 
 


### PR DESCRIPTION
Enable `ZMK_SPLIT_BLE_CENTRAL_BATTERY_LEVEL_FETCHING` + `_PROXY` on both centrals so the right half's battery is fetched over the split link and re-exposed as a second BLE Battery Service. Right half reports by default — no peripheral config, and the peripheral's existing firmware already supports the split-side send.

Also fixes `kbd_doctor battery` to read by characteristic handle (multiple 0x2A19 instances make UUID reads ambiguous) and label central vs proxied-peripheral.

## Verification (Vega)
Flashed central (serial-DFU fallback path), then `kbd_doctor battery`:
```
Vega-caa8ee2-P0: battery 100%  (central/left, char handle 17)
Vega-caa8ee2-P0: battery 100%  (peripheral #1 (proxied), char handle 22)
(2 Battery Service instances — split-battery proxy is working)
```
Both 100% because both halves are on USB; the proxy mechanism is confirmed. A distinct on-battery number just needs a half unplugged.

Note: macOS's Bluetooth menu may show only one of the two BAS instances (OS limitation); tools read both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)